### PR TITLE
add types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "author": "Felix Becker <felix.b@outlook.com>",
   "license": "ISC",
+  "types": "./lib/index.d.ts",
   "devDependencies": {
     "tslint": "^4.0.2",
     "typescript": "^2.0.9",


### PR DESCRIPTION
Adding the types field to package.json means this can be installed directly from `npm` without having `typings` installed:

`npm install akdor1154/npm-ldapjs` (or `types/npm-ldapjs` once/if this is merged!)

I guess it will also be necessary once @types can redirect to the typings repository...