### PR TITLE
fixed double slash that caused typings to break

### DIFF
--- a/lib/messages/bind_response.d.ts
+++ b/lib/messages/bind_response.d.ts
@@ -1,4 +1,4 @@
-import LDAPResult = require('.//result');
+import LDAPResult = require('./result');
 
 declare class BindResponse extends LDAPResult { }
 


### PR DESCRIPTION
This is fixing a stray double slash in an import statement that was breaking `typings` downstream.
[Typings PR 988](https://github.com/typings/registry/pull/988)